### PR TITLE
Fix patch session endpoint

### DIFF
--- a/backend/src/schedules/router.py
+++ b/backend/src/schedules/router.py
@@ -1054,7 +1054,7 @@ async def update_schedule_session(
     session_id: str,
     payload: schemas.UpdateScheduleSessionRequest,
     neo4j_session=Depends(get_neo4j_session),
-    _current_user: user_models.Users = Depends(require_permission("schedule:update")),
+    _current_user: user_models.Users = Depends(require_permission("class-session:update")),
 ):
     """
     Update a scheduled class session.

--- a/backend/src/schedules/router.py
+++ b/backend/src/schedules/router.py
@@ -1054,7 +1054,9 @@ async def update_schedule_session(
     session_id: str,
     payload: schemas.UpdateScheduleSessionRequest,
     neo4j_session=Depends(get_neo4j_session),
-    _current_user: user_models.Users = Depends(require_permission("class-session:update")),
+    _current_user: user_models.Users = Depends(
+        require_permission("class-session:update")
+    ),
 ):
     """
     Update a scheduled class session.


### PR DESCRIPTION
1. It currently uses the "schedule" permission, while the permission available in the system is "class-session".
- Now it uses "class-session:update" permission

2. The Neo4j query expects the "$endTime" parameter, but the endpoint passes "end_time".
- Now it is ok
<img width="447" height="222" alt="image" src="https://github.com/user-attachments/assets/9a0bcb2b-6e3e-4ff9-bf82-179505a0dd05" />
<img width="407" height="342" alt="image" src="https://github.com/user-attachments/assets/a155f410-0bb6-441c-ada4-2a34b1db6b79" />


3. The frontend sends dayOfWeek values such as "MONDAY". Please verify the mapping in the _to_plural_day() helper.
- Now it is ok
<img width="372" height="302" alt="image" src="https://github.com/user-attachments/assets/d1282980-96a5-4337-a1e2-7a8150cb562d" />
