### PR TITLE
Public api management upgrade

### DIFF
--- a/backend/alembic/versions/ed1941bc6354_drop_user_api_keys_user_id_unique_.py
+++ b/backend/alembic/versions/ed1941bc6354_drop_user_api_keys_user_id_unique_.py
@@ -1,0 +1,28 @@
+"""drop_user_api_keys_user_id_unique_constraint
+
+Revision ID: ed1941bc6354
+Revises: fa0c1a493f77
+Create Date: 2026-06-22 16:45:11.727027
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ed1941bc6354'
+down_revision: Union[str, Sequence[str], None] = 'fa0c1a493f77'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_constraint('user_api_keys_user_id_key', 'user_api_keys', type_='unique')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.create_unique_constraint('user_api_keys_user_id_key', 'user_api_keys', ['user_id'])

--- a/frontend/src/api/domains/users/apikeys.ts
+++ b/frontend/src/api/domains/users/apikeys.ts
@@ -26,10 +26,18 @@ const extractErrorMessage = async (response: Response, fallback: string): Promis
     }
 };
 
-export const generateApiKey = async (): Promise<APIKeyResponse> => {
+export interface APIKeyInfo {
+    id: number;
+    name: string;
+    expiration_date: string;
+    is_active: boolean;
+}
+
+export const generateApiKey = async (name?: string): Promise<APIKeyResponse> => {
     const response = await fetch(`${USERS_URL}/api-keys/generate`, {
         method: 'POST',
         headers: getHeaders(),
+        body: JSON.stringify({ name: name || undefined }),
     });
 
     if (!response.ok) {
@@ -38,4 +46,29 @@ export const generateApiKey = async (): Promise<APIKeyResponse> => {
     }
 
     return response.json() as Promise<APIKeyResponse>;
+};
+
+export const fetchApiKeys = async (): Promise<APIKeyInfo[]> => {
+    const response = await fetch(`${USERS_URL}/api-keys`, {
+        headers: getHeaders(),
+    });
+
+    if (!response.ok) {
+        const message = await extractErrorMessage(response, 'Failed to fetch API keys');
+        throw new Error(message);
+    }
+
+    return response.json() as Promise<APIKeyInfo[]>;
+};
+
+export const revokeApiKey = async (keyId: number): Promise<void> => {
+    const response = await fetch(`${USERS_URL}/api-keys/${keyId}/revoke`, {
+        method: 'POST',
+        headers: getHeaders(),
+    });
+
+    if (!response.ok) {
+        const message = await extractErrorMessage(response, 'Failed to revoke API key');
+        throw new Error(message);
+    }
 };

--- a/frontend/src/components/Common/AppButton.tsx
+++ b/frontend/src/components/Common/AppButton.tsx
@@ -61,20 +61,22 @@ export function AppButton({variant = 'contained', loading, children, sx, ...prop
         );
     }
 
-    // text variant
-    return (
-        <Button
-            variant="text"
-            disabled={isDisabled}
-            startIcon={startIcon}
-            sx={{
-                color: 'primary.main',
-                '&:hover': {bgcolor: 'action.hover', color: 'primary.dark'},
-                ...baseSx,
-            }}
-            {...props}
-        >
-            {children}
-        </Button>
-    );
+    if (variant === 'text') {
+        // text variant
+        return (
+            <Button
+                variant="text"
+                disabled={isDisabled}
+                startIcon={startIcon}
+                sx={{
+                    color: 'primary.main',
+                    '&:hover': {bgcolor: 'action.hover', color: 'primary.dark'},
+                    ...baseSx,
+                }}
+                {...props}
+            >
+                {children}
+            </Button>
+        );
+    }
 }

--- a/frontend/src/components/Common/ListView.tsx
+++ b/frontend/src/components/Common/ListView.tsx
@@ -18,6 +18,7 @@ interface ListViewProps<T> {
     columns?: ListColumn<T>[];
     onItemClick?: (item: T) => void;
     onMenuOpen?: (e: React.MouseEvent<HTMLElement>, item: T) => void;
+    showActionButton?: (item: T) => boolean;
     onAddClick?: () => void;
     addLabel?: string;
     emptyMessage?: string;
@@ -34,6 +35,7 @@ export function ListView<T extends { id: number | string }>({
                                                                 columns = [],
                                                                 onItemClick,
                                                                 onMenuOpen,
+                                                                showActionButton,
                                                                 onAddClick,
                                                                 addLabel,
                                                                 emptyMessage,
@@ -153,7 +155,7 @@ export function ListView<T extends { id: number | string }>({
                                 </Box>
                             ))}
 
-                            {onMenuOpen && (
+                            {onMenuOpen && (!showActionButton || showActionButton(item)) && (
                                 <IconButton
                                     size="small"
                                     onClick={(e) => {

--- a/frontend/src/components/PublicAPI/APIKeyCreateModal.tsx
+++ b/frontend/src/components/PublicAPI/APIKeyCreateModal.tsx
@@ -1,0 +1,86 @@
+import {useState} from 'react';
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Box,
+    TextField,
+    Alert
+} from '@mui/material';
+import {useIntl} from 'react-intl';
+import {AppButton} from '@components/Common';
+
+interface APIKeyCreateModalProps {
+    open: boolean;
+    onClose: () => void;
+    onGenerate: (name: string) => Promise<void>;
+}
+
+export const APIKeyCreateModal = ({open, onClose, onGenerate}: APIKeyCreateModalProps) => {
+    const intl = useIntl();
+    const [name, setName] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleClose = () => {
+        if (loading) return;
+        setName('');
+        setError(null);
+        onClose();
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            await onGenerate(name.trim());
+            setName('');
+            setError(null);
+            onClose();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Error generating API key');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth
+            PaperProps={{sx: {borderRadius: '24px', p: 1}}}>
+            <DialogTitle sx={{fontWeight: 700, pb: 1}}>
+                {intl.formatMessage({id: 'publicapi.modalCreateTitle'})}
+            </DialogTitle>
+            <Box component="form" onSubmit={handleSubmit}>
+                <DialogContent sx={{py: 1}}>
+                    <Box sx={{display: 'flex', flexDirection: 'column', gap: 2, mt: 1}}>
+                        {error && (
+                            <Alert severity="error" sx={{borderRadius: '12px'}}>
+                                {error}
+                            </Alert>
+                        )}
+                        <TextField
+                            label={intl.formatMessage({id: 'publicapi.nameLabel'})}
+                            placeholder={intl.formatMessage({id: 'publicapi.namePlaceholder'})}
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            variant="outlined"
+                            size="small"
+                            fullWidth
+                            autoFocus
+                        />
+                    </Box>
+                </DialogContent>
+                <DialogActions sx={{p: 3, gap: 1}}>
+                    <AppButton variant="text" onClick={handleClose} disabled={loading} sx={{flexGrow: 1}}>
+                        {intl.formatMessage({id: 'academics.common.cancel'})}
+                    </AppButton>
+                    <AppButton type="submit" variant="contained" loading={loading} sx={{flexGrow: 1}}>
+                        {intl.formatMessage({id: 'publicapi.generateButton'})}
+                    </AppButton>
+                </DialogActions>
+            </Box>
+        </Dialog>
+    );
+};

--- a/frontend/src/components/PublicAPI/APIKeyGeneratorCard.tsx
+++ b/frontend/src/components/PublicAPI/APIKeyGeneratorCard.tsx
@@ -1,4 +1,4 @@
-import {Box, Typography, Paper, Alert} from '@mui/material';
+import {Box, Typography, Paper} from '@mui/material';
 import {Tag} from '@mui/icons-material';
 import {useIntl} from 'react-intl';
 import {AppButton} from '@components/Common';
@@ -6,11 +6,9 @@ import {useTheme} from '@mui/material/styles';
 
 interface APIKeyGeneratorCardProps {
     onGenerate: () => void;
-    loading: boolean;
-    error: string | null;
 }
 
-export const APIKeyGeneratorCard = ({onGenerate, loading, error}: APIKeyGeneratorCardProps) => {
+export const APIKeyGeneratorCard = ({onGenerate}: APIKeyGeneratorCardProps) => {
     const intl = useIntl();
     const theme = useTheme();
 
@@ -35,17 +33,10 @@ export const APIKeyGeneratorCard = ({onGenerate, loading, error}: APIKeyGenerato
                 </Box>
             </Box>
 
-            {error && (
-                <Alert severity="error" sx={{mb: 3, borderRadius: '12px'}}>
-                    {error}
-                </Alert>
-            )}
-
             <Box sx={{mt: 4}}>
                 <AppButton
                     variant="contained"
                     onClick={onGenerate}
-                    loading={loading}
                     startIcon={<Tag />}
                     sx={{px: 4}}
                 >

--- a/frontend/src/components/PublicAPI/APIKeyList.tsx
+++ b/frontend/src/components/PublicAPI/APIKeyList.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react';
-import {Box, Typography, Chip} from '@mui/material';
+import {Paper, Box, Typography, Chip} from '@mui/material';
 import {Key, AccessTime} from '@mui/icons-material';
 import {useIntl} from 'react-intl';
 import {useTheme, alpha} from '@mui/material/styles';
@@ -47,10 +47,7 @@ export const APIKeyList = ({keys, onRevoke}: APIKeyListProps) => {
     };
 
     return (
-        <Box sx={{mt: 4}}>
-            <Typography variant="h6" fontWeight={700} sx={{mb: 2}}>
-                {intl.formatMessage({id: 'publicapi.listTitle'})}
-            </Typography>
+        <Paper>
             <ListView<APIKeyInfo>
                 items={keys}
                 icon={Key}
@@ -120,6 +117,6 @@ export const APIKeyList = ({keys, onRevoke}: APIKeyListProps) => {
                 onConfirm={() => { void handleConfirmRevoke(); }}
                 onClose={() => setConfirmOpen(false)}
             />
-        </Box>
+        </Paper>
     );
 };

--- a/frontend/src/components/PublicAPI/APIKeyList.tsx
+++ b/frontend/src/components/PublicAPI/APIKeyList.tsx
@@ -1,0 +1,125 @@
+import {useState} from 'react';
+import {Box, Typography, Chip} from '@mui/material';
+import {Key, AccessTime} from '@mui/icons-material';
+import {useIntl} from 'react-intl';
+import {useTheme, alpha} from '@mui/material/styles';
+import {ListView, DeleteConfirmDialog, ActionMenu} from '@components/Common';
+import {type APIKeyInfo} from '@api/domains/users/apikeys';
+
+interface APIKeyListProps {
+    keys: APIKeyInfo[];
+    onRevoke: (keyId: number) => Promise<void>;
+}
+
+export const APIKeyList = ({keys, onRevoke}: APIKeyListProps) => {
+    const intl = useIntl();
+    const theme = useTheme();
+    const [confirmOpen, setConfirmOpen] = useState(false);
+    const [selectedKey, setSelectedKey] = useState<APIKeyInfo | null>(null);
+
+    const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
+    const [selectedKeyForMenu, setSelectedKeyForMenu] = useState<APIKeyInfo | null>(null);
+
+    const handleMenuOpen = (e: React.MouseEvent<HTMLElement>, key: APIKeyInfo) => {
+        if (!key.is_active) return;
+        setMenuAnchorEl(e.currentTarget);
+        setSelectedKeyForMenu(key);
+    };
+
+    const handleMenuClose = () => {
+        setMenuAnchorEl(null);
+    };
+
+    const handleRevokeClick = (key: APIKeyInfo) => {
+        setSelectedKey(key);
+        setConfirmOpen(true);
+        handleMenuClose();
+    };
+
+    const handleConfirmRevoke = async () => {
+        if (!selectedKey) return;
+        setConfirmOpen(false);
+        try {
+            await onRevoke(selectedKey.id);
+        } finally {
+            setSelectedKey(null);
+        }
+    };
+
+    return (
+        <Box sx={{mt: 4}}>
+            <Typography variant="h6" fontWeight={700} sx={{mb: 2}}>
+                {intl.formatMessage({id: 'publicapi.listTitle'})}
+            </Typography>
+            <ListView<APIKeyInfo>
+                items={keys}
+                icon={Key}
+                getTitle={(item) => item.name}
+                titleWidth="250px"
+                emptyMessage={intl.formatMessage({id: 'publicapi.noKeys'})}
+                onMenuOpen={handleMenuOpen}
+                showActionButton={(item) => item.is_active}
+                columns={[
+                    {
+                        render: (item) => (
+                            <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
+                                <AccessTime sx={{fontSize: 16, color: 'text.secondary', opacity: 0.8}}/>
+                                <Typography variant="body2" color="text.secondary">
+                                    {item.expiration_date}
+                                </Typography>
+                            </Box>
+                        ),
+                        width: '250px',
+                    },
+                    {
+                        render: (item) => (
+                            <Chip
+                                label={intl.formatMessage({
+                                    id: item.is_active ? 'publicapi.active' : 'publicapi.revoked'
+                                })}
+                                color={item.is_active ? 'success' : 'default'}
+                                size="small"
+                                sx={{
+                                    fontWeight: 600,
+                                    bgcolor: item.is_active 
+                                        ? alpha(theme.palette.success.main, 0.08) 
+                                        : alpha(theme.palette.action.disabled, 0.08),
+                                    color: item.is_active 
+                                        ? theme.palette.success.main 
+                                        : theme.palette.text.secondary,
+                                    border: 'none'
+                                }}
+                            />
+                        ),
+                        width: '150px',
+                    }
+                ]}
+            />
+
+            <ActionMenu
+                anchorEl={menuAnchorEl}
+                onClose={handleMenuClose}
+                onDelete={() => {
+                    if (selectedKeyForMenu) {
+                        handleRevokeClick(selectedKeyForMenu);
+                    }
+                }}
+                deleteLabel={intl.formatMessage({id: 'academics.students.delete'})}
+                hideEdit
+            />
+
+            <DeleteConfirmDialog
+                open={confirmOpen}
+                title={intl.formatMessage({id: 'publicapi.revokeConfirmTitle'})}
+                description={intl.formatMessage(
+                    {id: 'publicapi.revokeConfirmDesc'},
+                    {name: selectedKey?.name}
+                )}
+                cancelButtonLabel={intl.formatMessage({id: 'academics.common.cancel'})}
+                confirmButtonLabel={intl.formatMessage({id: 'publicapi.revokeConfirmTitle'})}
+                onConfirm={() => { void handleConfirmRevoke(); }}
+                onClose={() => setConfirmOpen(false)}
+            />
+        </Box>
+    );
+};

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2,7 +2,8 @@
   "common": {
     "cancel": "Cancel",
     "save": "Save",
-    "saving": "Saving..."
+    "saving": "Saving...",
+    "delete": "Delete"
   },
   "login": {
     "title": "Sign in",
@@ -110,6 +111,22 @@
     "title": "Public API Access Keys",
     "description": "Manage your API keys to access the system programmatically.",
     "generateButton": "Generate new API key",
+    "keyName": "Key Name",
+    "expiration": "Expiration Date",
+    "status": "Status",
+    "active": "Active",
+    "revoked": "Revoked",
+    "namePlaceholder": "e.g. Schedule import script",
+    "nameLabel": "Friendly key name",
+    "modalCreateTitle": "Create new API key",
+    "errors": {
+      "nameRequired": "API key must have a name."
+    },
+    "revokeConfirmTitle": "Deactivate API Key?",
+    "revokeConfirmDesc": "Are you sure you want to deactivate this API key? Clients using it will lose access immediately.",
+    "revokeSuccess": "API key has been deactivated.",
+    "listTitle": "Your API Keys",
+    "noKeys": "No API keys generated yet.",
     "modal": {
       "title": "New API Key",
       "description": "This is your new API key. Make sure to copy it now, as it will not be shown again.",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -2,7 +2,8 @@
   "common": {
     "cancel": "Anuluj",
     "save": "Zapisz",
-    "saving": "Zapisywanie..."
+    "saving": "Zapisywanie...",
+    "delete": "Usuń"
   },
   "login": {
     "title": "Zaloguj się",
@@ -110,6 +111,22 @@
     "title": "Klucze dostępu Publicznego API",
     "description": "Zarządzaj swoimi kluczami API, aby uzyskać programowy dostęp do systemu.",
     "generateButton": "Generuj nowy klucz API",
+    "keyName": "Nazwa klucza",
+    "expiration": "Data ważności",
+    "status": "Status",
+    "active": "Aktywny",
+    "revoked": "Deaktywowany",
+    "namePlaceholder": "Np. Skrypt do pobierania planu",
+    "nameLabel": "Przyjazna nazwa klucza",
+    "modalCreateTitle": "Utwórz nowy klucz API",
+    "errors": {
+      "nameRequired": "Klucz API musi mieć nazwę."
+    },
+    "revokeConfirmTitle": "Deaktywować klucz API?",
+    "revokeConfirmDesc": "Czy na pewno chcesz deaktywować ten klucz API? Klienci używający go stracą dostęp natychmiast.",
+    "revokeSuccess": "Klucz API został deaktywowany.",
+    "listTitle": "Twoje klucze API",
+    "noKeys": "Brak wygenerowanych kluczy API.",
     "modal": {
       "title": "Nowy Klucz API",
       "description": "To jest Twój nowy klucz API. Skopiuj go teraz, ponieważ nie zostanie wyświetlony ponownie.",

--- a/frontend/src/pages/PublicAPI/APIKeysPage.tsx
+++ b/frontend/src/pages/PublicAPI/APIKeysPage.tsx
@@ -1,39 +1,123 @@
-import {useState} from 'react';
-import {Box} from '@mui/material';
+import {useState, useEffect, useCallback} from 'react';
+import {Box, CircularProgress, Alert, Snackbar} from '@mui/material';
 import {useIntl} from 'react-intl';
 import {PageBreadcrumbs, type BreadcrumbItem} from '@components/Common';
-import {generateApiKey} from '@api/domains/users/apikeys';
+import {generateApiKey, fetchApiKeys, revokeApiKey, type APIKeyInfo} from '@api/domains/users/apikeys';
 import APIKeyDisplayModal from '@components/PublicAPI/APIKeyDisplayModal.tsx';
 import {APIKeyGeneratorCard} from '@components/PublicAPI/APIKeyGeneratorCard';
+import {APIKeyList} from '@components/PublicAPI/APIKeyList';
+import {APIKeyCreateModal} from '@components/PublicAPI/APIKeyCreateModal';
 
 export default function APIKeysPage() {
     const intl = useIntl();
-    const [loading, setLoading] = useState(false);
     const [newKey, setNewKey] = useState<string | null>(null);
     const [modalOpen, setModalOpen] = useState(false);
-    const [error, setError] = useState<string | null>(null);
+    const [createModalOpen, setCreateModalOpen] = useState(false);
+    
+    const [keys, setKeys] = useState<APIKeyInfo[]>([]);
+    const [listLoading, setListLoading] = useState(false);
+    const [listError, setListError] = useState<string | null>(null);
+
+    const [snackbarOpen, setSnackbarOpen] = useState(false);
+    const [snackbarMessage, setSnackbarMessage] = useState('');
+    const [snackbarSeverity, setSnackbarSeverity] = useState<'success' | 'error'>('success');
 
     const breadcrumbs: BreadcrumbItem[] = [{label: intl.formatMessage({id: 'sidebar.publicapi'}), path: '/public-api'}];
 
-    const handleGenerate = async () => {
-        setLoading(true);
-        setError(null);
+    const showSnackbar = (message: string, severity: 'success' | 'error') => {
+        setSnackbarMessage(message);
+        setSnackbarSeverity(severity);
+        setSnackbarOpen(true);
+    };
+
+    const loadKeys = useCallback(async () => {
+        setListLoading(true);
+        setListError(null);
         try {
-            const data = await generateApiKey();
+            const data = await fetchApiKeys();
+            setKeys(data);
+        } catch (err) {
+            setListError(err instanceof Error ? err.message : 'Error fetching API keys');
+        } finally {
+            setListLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void loadKeys();
+    }, [loadKeys]);
+
+    const handleGenerate = async (name: string): Promise<void> => {
+        const trimmedName = name.trim();
+        if (!trimmedName) {
+            const errorMsg = intl.formatMessage({id: 'publicapi.errors.nameRequired'});
+            showSnackbar(errorMsg, 'error');
+            throw new Error(errorMsg);
+        }
+
+        try {
+            const data = await generateApiKey(trimmedName);
             setNewKey(data.api_key);
             setModalOpen(true);
+            void loadKeys();
         } catch (err) {
-            setError(err instanceof Error ? err.message : 'Error generating API key');
-        } finally {
-            setLoading(false);
+            const errorMsg = err instanceof Error ? err.message : 'Error generating API key';
+            showSnackbar(errorMsg, 'error');
+            throw err;
+        }
+    };
+
+    const handleRevoke = async (keyId: number) => {
+        try {
+            await revokeApiKey(keyId);
+            void loadKeys();
+            showSnackbar(intl.formatMessage({id: 'publicapi.revokeSuccess'}), 'success');
+        } catch (err) {
+            const errorMsg = err instanceof Error ? err.message : 'Error revoking API key';
+            showSnackbar(errorMsg, 'error');
         }
     };
 
     return (
         <Box sx={{display: 'flex', flexDirection: 'column', gap: 3, width: '100%'}}>
             <PageBreadcrumbs items={breadcrumbs}/>
-            <APIKeyGeneratorCard onGenerate={() => { void handleGenerate(); }} loading={loading} error={error} />
+
+            <APIKeyGeneratorCard onGenerate={() => setCreateModalOpen(true)} />
+            
+            {listLoading && (
+                <Box sx={{display: 'flex', justifyContent: 'center', py: 4}}>
+                    <CircularProgress />
+                </Box>
+            )}
+            
+            {listError && (
+                <Alert severity="error" sx={{borderRadius: '12px'}}>
+                    {listError}
+                </Alert>
+            )}
+
+            {!listLoading && !listError && (
+                <APIKeyList keys={keys} onRevoke={handleRevoke} />
+            )}
+
+            <APIKeyCreateModal
+                open={createModalOpen}
+                onClose={() => setCreateModalOpen(false)}
+                onGenerate={handleGenerate}
+            />
+
             <APIKeyDisplayModal open={modalOpen} apiKey={newKey} onClose={() => setModalOpen(false)} />
+
+            <Snackbar
+                open={snackbarOpen}
+                autoHideDuration={4000}
+                onClose={() => setSnackbarOpen(false)}
+                anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+            >
+                <Alert severity={snackbarSeverity} sx={{width: '100%', borderRadius: '12px', boxShadow: 3}}>
+                    {snackbarMessage}
+                </Alert>
+            </Snackbar>
         </Box>
     );
 }


### PR DESCRIPTION
Add the ability to manage your keys. When revoked, they remain on the list but the action menu is hidden.

<img width="1917" height="868" alt="image" src="https://github.com/user-attachments/assets/0890f766-2709-47ec-a645-bd806c136439" />
<img width="1917" height="866" alt="image" src="https://github.com/user-attachments/assets/4a12cfc1-f706-4d17-8e8a-6bc2833b52ea" />
<img width="1917" height="866" alt="image" src="https://github.com/user-attachments/assets/ac9ad09d-642d-49db-ba8c-b687b3d67ef3" />
