### PR TITLE
Change PUT to PATCH in editing session

### DIFF
--- a/frontend/src/api/domains/schedules/schedules.ts
+++ b/frontend/src/api/domains/schedules/schedules.ts
@@ -70,7 +70,7 @@ export const updateScheduleSession = async (
     payload: UpdateScheduleSessionRequest,
 ): Promise<void> => {
     const response = await fetch(`${SCHEDULES_URL}/session/${sessionId}`, {
-        method: 'PUT',
+        method: 'PATCH',
         headers: getHeaders(),
         body: JSON.stringify(payload),
     });


### PR DESCRIPTION
<img width="1912" height="870" alt="image" src="https://github.com/user-attachments/assets/fd2fb081-b505-4000-b8c4-8e6d2eabdf8a" />
The problem (405 Method Not Allowed) occured because the frontend was sending a PUT request, but the backend FastAPI endpoint expects a PATCH request for partial updates. 
In my opinion there is no need for more detailed information since the information is already detailed enough as seen above. Edting session works correctly now.